### PR TITLE
fix: correct punctuation in comment for Java setup step in SonarCloud analysis workflow

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Step 1: Set up Java 17 for SonarCloud
+      # Step 1: Set up Java 17 for SonarCloud.
       - name: Set up JDK 17 for SonarCloud analysis
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/sonarcloud-analysis.yml` file. The change adds a period to the comment describing the step for setting up Java 17 for SonarCloud analysis.