### PR TITLE
♻️ refactor(star.module): remove AgressoToolsService from providers a…

### DIFF
--- a/data-synchronization/src/domain/connections/star-main-app/star.module.ts
+++ b/data-synchronization/src/domain/connections/star-main-app/star.module.ts
@@ -4,22 +4,11 @@ import { HttpModule } from '@nestjs/axios';
 import { ClarisaInstitutionsRepository } from './entities/clarisa-institutions/repositories/clarisa-institution.repository';
 import { StarService } from './star.service';
 import { StarCronJob } from './cron-jobs/star-cronjob';
-import { AgressoToolsService } from './entities/agresso-contract/agresso-tools.service';
 
 @Module({
   imports: [HttpModule],
   controllers: [StarController],
-  providers: [
-    ClarisaInstitutionsRepository,
-    StarService,
-    StarCronJob,
-    AgressoToolsService,
-  ],
-  exports: [
-    StarService,
-    ClarisaInstitutionsRepository,
-    StarCronJob,
-    AgressoToolsService,
-  ],
+  providers: [ClarisaInstitutionsRepository, StarService, StarCronJob],
+  exports: [StarService, ClarisaInstitutionsRepository, StarCronJob],
 })
 export class StarModule {}

--- a/data-synchronization/src/domain/connections/star-main-app/star.service.ts
+++ b/data-synchronization/src/domain/connections/star-main-app/star.service.ts
@@ -31,7 +31,6 @@ import { ClarisaInnovationCharacteristic } from './entities/clarisa-innovation-c
 import { ClarisaInnovationReadinessLevel } from './entities/clarisa-innovation-readiness-levels/clarisa-innovation-readiness-level.entity';
 import { ClarisaInnovationType } from './entities/clarisa-innovation-types/clarisa-innovation-type.entity';
 import { ClarisaSdg } from './entities/clarisa-sdgs/clarisa-sdg.entity';
-import { AgressoToolsService } from './entities/agresso-contract/agresso-tools.service';
 
 @Injectable()
 export class StarService extends BaseApi {
@@ -39,7 +38,6 @@ export class StarService extends BaseApi {
     @InjectDataSource('STAR') private dataSource: DataSource,
     httpService: HttpService,
     private readonly ciRepo: ClarisaInstitutionsRepository,
-    private readonly agressoService: AgressoToolsService,
   ) {
     super(
       httpService,
@@ -164,8 +162,6 @@ export class StarService extends BaseApi {
       ClarisaPathEnum.GEO_SCOPES,
       ClarisaGeoScope,
     );
-
-    await this.agressoService.cloneAllAgressoEntities();
 
     this.logger.debug('All entities cloned');
   }


### PR DESCRIPTION
This pull request removes the dependency on the `AgressoToolsService` from the `StarModule` and `StarService`, streamlining the code by eliminating unused or unnecessary service injections and calls.

Dependency removal and cleanup:

* Removed `AgressoToolsService` from the `providers` and `exports` arrays in the `StarModule`, as well as its import statement, to simplify module dependencies.
* Removed the injection and usage of `AgressoToolsService` from the `StarService` class, including the constructor parameter and the call to `cloneAllAgressoEntities()`. [[1]](diffhunk://#diff-96399e8ca896ca4cdde48fb1e611e1c0b2f3208ccf02f41e502c38a2ef7db86bL34-L42) [[2]](diffhunk://#diff-96399e8ca896ca4cdde48fb1e611e1c0b2f3208ccf02f41e502c38a2ef7db86bL168-L169)…nd exports